### PR TITLE
fix/min-zoom-button

### DIFF
--- a/components/EventFlow.tsx
+++ b/components/EventFlow.tsx
@@ -331,7 +331,6 @@ function Flow({
       requestAnimationFrame(() => {
         fitView({
           includeHiddenNodes: false,
-          minZoom: 0.05, // Zoom on larger nodes
         });
       });
     }
@@ -355,11 +354,12 @@ function Flow({
         onDragOver={onDragOver}
         onInit={setRfInstance}
         nodeTypes={nodeTypes}
+        minZoom={0.1}
         nodesDraggable={isEditable}
         elementsSelectable={isEditable}
         className="touch-none"
       >
-        <Controls position="bottom-right" fitViewOptions={{ minZoom: 0.05 }}/>
+        <Controls position="bottom-right" />
 
         {/* Hide legend on view only mode */}
         {isEditable && <Legend />}
@@ -367,43 +367,6 @@ function Flow({
 
         <EventMapSelect eventId={event.id} locations={eventLocations} />
       </ReactFlow>
-
-      {/* Hide save button in view mode
-      {isEditable && (
-        <Button
-          onClick={() =>
-            rfInstance &&
-            eventLocation &&
-            SaveState(
-              event.id,
-              eventLocation.locationId,
-              JSON.stringify(rfInstance.toObject()),
-            )}
-          style={{ position: "fixed", top: "4rem", right: 16 }}
-          variant="default"
-        >
-          Save
-        </Button>
-      )}
-      {isEditable && (
-        <Button
-          onClick={onUndo}
-          style={{ position: "fixed", top: "7rem", right: 16 }}
-          variant="contained"
-        >
-          Undo
-        </Button>
-      )}
-      {isEditable && (
-        <Button
-          onClick={onRedo}
-          style={{ position: "fixed", top: "10rem", right: 16 }}
-          variant="contained"
-        >
-          Redo
-        </Button>
-      )}
-      */}
     </div>
   );
 }
@@ -416,7 +379,7 @@ export default function EventFlow({
   location: string;
   isEditable: boolean;
 }) {
-  return (  
+  return (
     <ReactFlowProvider>
       <ChannelProvider channelName="event-updates">
         <Flow event={event} location={location} isEditable={isEditable} />


### PR DESCRIPTION
Made minZoom apply to the entire ReactFlow component instead of just the fitView function. This makes the zoomOut functionality more consistent across every method and makes sure we can use large images.

Closes #96 